### PR TITLE
Add disable_backups flag

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,5 +11,8 @@ platforms:
 suites:
 - name: default
   run_list:
-  - recipe[test]
-  - recipe[emacs]
+    - recipe[test]
+    - recipe[emacs]
+  attributes:
+    emacs:
+      disable_backups: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,15 @@ default['emacs']['packages'] = case node['platform_family']
                                else
                                  ['emacs']
                                end
+
+case node['platform_family']
+when 'debian'
+  default['emacs']['site-start-path'] = '/etc/emacs/site-start.d'
+when 'rhel', 'fedora', 'arch'
+  default['emacs']['site-start-path'] = '/usr/share/emacs/site-lisp/site-start.d'
+else
+  default['emacs']['site-start-path'] = nil
+  Chef::Log.warn("site-start path not known for platform #{node['platform_family']}, please add it.")
+end
+
+default['emacs']['disable_backups'] = false

--- a/files/default/70nobackups.el
+++ b/files/default/70nobackups.el
@@ -1,0 +1,6 @@
+;CHEF MANAGED FILE: DO NOT EDIT
+;disable backup
+(setq backup-inhibited t)
+;disable auto save
+(setq auto-save-default nil)
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,3 +22,13 @@ node['emacs']['packages'].each do |pkg|
     source 'ports' if platform?('freebsd') && node['platform_version'].to_f < 10.0
   end
 end
+
+if node['emacs']['disable_backups']
+  fail("['emacs']['site-start-path'] unset, cannot place site-start file") unless node['emacs']['site-start-path']
+  cookbook_file "#{node['emacs']['site-start-path']}/70nobackups.el" do
+    source '70nobackups.el'
+    owner 'root'
+    group 'root'
+    mode 0644
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -8,4 +8,21 @@ describe 'emacs' do
   it 'should have emacs version 24' do
     expect(emacs_version.stdout).to match(/^GNU Emacs 24/)
   end
+
+  describe 'backups disable file' do
+    site_start_dir = case host_inventory['platform']
+                     when 'debian', 'ubuntu'
+                       '/etc/emacs/site-start.d'
+                     when 'redhat', 'centos'
+                       '/usr/share/emacs/site-lisp/site-start.d'
+                     else
+                       fail("Unknown platform #{host_inventory['platform']}")
+                     end
+
+    describe file "#{site_start_dir}/70nobackups.el" do
+      it { should be_file }
+      it { should contain '(setq backup-inhibited t)' }
+      it { should contain '(setq auto-save-default nil)' }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a disable_backups setting.  The default is false and does not change the behavior of the cookbook.  When set to true the cookbook will drop a el file into the site-start directory which will disable backup files and autosave files which can cruft up a box.  This is based on https://github.com/TJNII/puppet-emacs